### PR TITLE
Add optional keep-alive functionality

### DIFF
--- a/benchmark/factory.benchmark.cc
+++ b/benchmark/factory.benchmark.cc
@@ -49,6 +49,16 @@ static void Create(State& state) {
     DoNotOptimize(factory.get(0, []() { return new int{0}; }));
   }
 }
+BENCHMARK(Create);
+
+static void CreateWithKeepAlive(State& state) {
+  UniqueFactory<int, int, KeepSetAlive<int, 16>> factory;
+
+  for (auto _ : state) {
+    DoNotOptimize(factory.get(0, []() { return new int{0}; }));
+  }
+}
+BENCHMARK(CreateWithKeepAlive);
 
 }
 }

--- a/test/factory.test.cc
+++ b/test/factory.test.cc
@@ -47,6 +47,18 @@ TEST_CASE("Factory", "[factory]"){
 
     REQUIRE(*factory.get(0, []() { return new int{1}; }) == 1);
   }
+
+  SECTION("Values can be Kept Alive") {
+    UniqueFactory<int, int, KeepSetAlive<int, 1>> factory;
+
+    factory.get(0, []() { return new int{0}; });
+
+    REQUIRE(*factory.get(0, []() { return new int{1}; }) == 0);
+
+    factory.get(1, []() { return new int{0}; });
+
+    REQUIRE(*factory.get(0, []() { return new int{1}; }) == 1);
+  }
 }
 
 }


### PR DESCRIPTION
this benefits use-cases such as exact-real. When computing `x*x` in a
loop in exact-real, the parent of `x*x` is recreated in every invocation
which is very expensive.