### PR TITLE
Keep cache consistent when value creation throws

### DIFF
--- a/doc/news/catch.rst
+++ b/doc/news/catch.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* Fixed cache inconsistency when factory function `create()` throws an exception.

--- a/test/factory.test.cc
+++ b/test/factory.test.cc
@@ -75,6 +75,14 @@ TEST_CASE("Factory", "[factory]"){
       value = factory.get(0, []() { return new UniqueInt{0}; });
     }
   }
+
+  SECTION("Factory can handle Failures") {
+    UniqueFactory<int, UniqueInt, KeepSetAlive<UniqueInt, 1>> factory;
+
+    REQUIRE_THROWS_AS(factory.get(0, []() -> UniqueInt* { throw std::logic_error("failure"); }), std::logic_error);
+
+    REQUIRE(factory.get(0, []() { return new UniqueInt{0}; })->value == 0);
+  }
 }
 
 }

--- a/unique-factory/unique-factory.hpp
+++ b/unique-factory/unique-factory.hpp
@@ -110,7 +110,12 @@ class UniqueFactory : KeepAlive {
 
     auto [it, inserted] = cache.try_emplace(std::forward<K>(key));
     if (inserted) {
-      it->second = create(it->first);
+      try {
+        it->second = create(it->first);
+      } catch (...) {
+        cache.erase(it);
+        throw;
+      }
       ret = std::shared_ptr<const Value>(it->second, Deleter(this, it->first));
     } else {
       ret = it->second->shared_from_this();


### PR DESCRIPTION
Checklist
* [x] Added an entry in `doc/news/`. <!-- Copy the TEMPLATE.rst to mybranch.rst, fill in the relevant sections, delete the others. -->
* [x] Added a test/benchmark for this change.